### PR TITLE
Bump version + colcon-bundle version

### DIFF
--- a/colcon_ros_bundle/__init__.py
+++ b/colcon_ros_bundle/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = '0.0.11'
+__version__ = '0.0.12'

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst
 [options]
 python_requires = >=3.5
 install_requires =
-    colcon-bundle>=0.0.13
+    colcon-bundle>=0.0.15
     colcon-ros>=0.3.5
     rosdep<=0.14.0
     setuptools>=30.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ long_description = file: README.rst
 [options]
 python_requires = >=3.5
 install_requires =
-    colcon-bundle>=0.0.10
+    colcon-bundle>=0.0.13
     colcon-ros>=0.3.5
     rosdep<=0.14.0
     setuptools>=30.3.0

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -6,4 +6,4 @@ import colcon_ros_bundle
 
 def test_version():
     version = colcon_ros_bundle.__version__
-    assert version == '0.0.11'
+    assert version == '0.0.12'


### PR DESCRIPTION
A new version of colcon-bundle with a new packaging format was released on March 25th but this package was never bumped. Bumping this package version so that when users upgrade (with  `pip install -U colcon-ros-bundle`) they will get the latest version of colcon-bundle. 
