### PR TITLE
Support versioned and unversioned dependencies in python packages

### DIFF
--- a/colcon_ros_bundle/task/ament_python/bundle.py
+++ b/colcon_ros_bundle/task/ament_python/bundle.py
@@ -36,13 +36,17 @@ class RosAmentPythonBundleTask(TaskExtensionPoint):
                     'because it is in the workspace'.format_map(locals()))
                 continue
 
+            # Currently, only the first five of these mappings are supported by colcon-core
+            # The others are added for completeness with PEP 440
             symbol_mapping = {
                 'version_eq': '==',
-                'version_neq': '!=',
                 'version_lte': '<=',
                 'version_gte': '>=',
                 'version_gt': '>',
                 'version_lt': '<',
+                'version_neq': '!=',
+                'version_aeq': '===',
+                'version_compatible': '~=',
             }
 
             pip = args.installers['pip3']

--- a/colcon_ros_bundle/task/ament_python/bundle.py
+++ b/colcon_ros_bundle/task/ament_python/bundle.py
@@ -36,8 +36,9 @@ class RosAmentPythonBundleTask(TaskExtensionPoint):
                     'because it is in the workspace'.format_map(locals()))
                 continue
 
-            # Currently, only the first five of these mappings are supported by colcon-core
-            # The others are added for completeness with PEP 440
+            # Currently, only the first five of these mappings are supported
+            # by colcon-core. The others are added for completeness with
+            # PEP 440.
             symbol_mapping = {
                 'version_eq': '==',
                 'version_lte': '<=',

--- a/colcon_ros_bundle/task/ament_python/bundle.py
+++ b/colcon_ros_bundle/task/ament_python/bundle.py
@@ -36,15 +36,27 @@ class RosAmentPythonBundleTask(TaskExtensionPoint):
                     'because it is in the workspace'.format_map(locals()))
                 continue
 
-            if 'version_eq' in dependency.metadata:
-                pip = args.installers['pip3']
+            symbol_mapping = {
+                'version_eq': '==',
+                'version_neq': '!=',
+                'version_lte': '<=',
+                'version_gte': '>=',
+                'version_gt': '>',
+                'version_lt': '<',
+            }
+
+            pip = args.installers['pip3']
+            versioned = False
+            for comparator, version in dependency.metadata.items():
+                if symbol_mapping.get(comparator) is not None:
+                    versioned = True
+                    pip.add_to_install_list(
+                        dependency.name + symbol_mapping[comparator] + version
+                    )
+            if not versioned:
                 pip.add_to_install_list(
-                    dependency.name + '==' + dependency.metadata['version_eq'])
-            else:
-                logger.warning('Currently only support version locked '
-                               'packages. Skipping: {dependency}'
-                               .format(dependency=dependency))
-                continue
+                    dependency.name
+                )
 
             # TODO: The Pip managers should be doing this
             apt = args.installers['apt']


### PR DESCRIPTION
`colcon-bundle` python support was upgraded with this functionality, figured I'd add it here too.

This makes it so that all python dependencies will be installed regardless of their version specifiers. Pip will error out if there are conflicting version specifiers, we don't need to do that check here.