### PR TITLE
skip if package_name_list len is zero

### DIFF
--- a/colcon_ros_bundle/task/ros_bundle.py
+++ b/colcon_ros_bundle/task/ros_bundle.py
@@ -60,6 +60,8 @@ class RosBundle(TaskExtensionPoint):
                     args.installers['apt'].add_to_install_list('python-pip')
 
                 package_name_list = rosdep.resolve(rule)
+                if len(package_name_list) == 0:
+                    continue
                 if len(package_name_list) > 1:
                     logger.info('{dependency} returned {package_name_list}'
                                 .format_map(locals()))


### PR DESCRIPTION
# This PR
https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L471-L498 for ubuntu contains empty rule so `rosdep.resolve(rule)` returns empty array and raises exception.
This PR fixes this issue.

# How to reproduce this issue
```bash
mkdir path/to/src
cd path/to/src
git clone https://github.com/KIT-MRT/mrt_cmake_modules.git
cd ../
colcon build
colcon bundle
```