### PR TITLE
Fix query on ROS_DISTRO so bundle doesn't suppress 'ROS_DISTRO not defined' error.

### DIFF
--- a/colcon_ros_bundle/task/ros_bundle.py
+++ b/colcon_ros_bundle/task/ros_bundle.py
@@ -84,3 +84,4 @@ class RosBundle(TaskExtensionPoint):
         else:
             logger.error('ROS_DISTRO is not defined make sure to '
                          'source your ROS environment.')
+            raise RuntimeError("ROS_DISTRO is not defined. Make sure to source your ROS environment.")

--- a/colcon_ros_bundle/task/ros_bundle.py
+++ b/colcon_ros_bundle/task/ros_bundle.py
@@ -75,18 +75,12 @@ class RosBundle(TaskExtensionPoint):
                         os_specific_dependency=package_name_list,
                         installer=rule_installer))
 
-        if not False:
-            logger.info('Including ros-base')
-            try:
-                ros_distro = os.environ.get('ROS_DISTRO')
-                if ros_distro is not None:
-                    args.installers['apt'].add_to_install_list(
-                        'ros-{ros_distro}-ros-base'.format(
-                            ros_distro=ros_distro))
-                else:
-                    logger.error('ROS_DISTRO is not defined make sure to'
-                                 'source your ROS environment.')
-                    raise RuntimeError('ROS_DISTRO environment variable '
-                                       'not defined.')
-            except KeyError:
-                logger.error('Could not find package')
+        logger.info('Including ros-base')
+        ros_distro = os.environ.get('ROS_DISTRO')
+        if ros_distro is not None:
+            args.installers['apt'].add_to_install_list(
+                'ros-{ros_distro}-ros-base'.format(
+                    ros_distro=ros_distro))
+        else:
+            logger.error('ROS_DISTRO is not defined make sure to '
+                         'source your ROS environment.')

--- a/colcon_ros_bundle/task/ros_bundle.py
+++ b/colcon_ros_bundle/task/ros_bundle.py
@@ -78,7 +78,7 @@ class RosBundle(TaskExtensionPoint):
         if not False:
             logger.info('Including ros-base')
             try:
-                ros_distro = os.environ['ROS_DISTRO']
+                ros_distro = os.environ.get('ROS_DISTRO')
                 if ros_distro is not None:
                     args.installers['apt'].add_to_install_list(
                         'ros-{ros_distro}-ros-base'.format(

--- a/test/test_catkin_bundle.py
+++ b/test/test_catkin_bundle.py
@@ -20,10 +20,10 @@ async def test_bundle():
         DependencyDescriptor('system_pkg')
     }
     installers = {
+        'apt': MagicMock(),
         'rdmanifest': MagicMock(),
-        'system': MagicMock(),
         'other': MagicMock(),
-        'apt': MagicMock()
+        'system': MagicMock()
     }
     top_level_args = MagicMock(build_base='build/base',
                                install_base='install/base',

--- a/test/test_catkin_bundle.py
+++ b/test/test_catkin_bundle.py
@@ -38,7 +38,7 @@ async def test_bundle():
     # http://www.voidspace.org.uk/python/mock/patch.html#where-to-patch
     with patch('colcon_ros_bundle.task.ros_bundle.RosdepWrapper') as wrapper:  # noqa: E501
         with patch('os.environ') as environ:
-            environ.__getitem__.side_effect = access_var
+            environ.get = access_var
             wrapper().get_rule.side_effect = _get_rule_side_effect
             wrapper().resolve.side_effect = _resolve_side_effect
             await task.bundle()
@@ -109,7 +109,7 @@ def access_var(key):
 
 
 @pytest.mark.asyncio
-async def test_exclude_ros_base():
+async def test_rosdistro_not_defined():
     pkg = PackageDescriptor('package/path')
     pkg.name = 'MyPackageName'
     pkg.dependencies['run'] = {}
@@ -128,8 +128,9 @@ async def test_exclude_ros_base():
     # Concise read on why it's patched this way.
     # http://www.voidspace.org.uk/python/mock/patch.html#where-to-patch
     with patch('colcon_ros_bundle.task.ros_bundle.RosdepWrapper') as wrapper:  # noqa: E501
-        wrapper().get_rule.side_effect = _get_rule_side_effect
-        wrapper().resolve.side_effect = _resolve_side_effect
-        await task.bundle()
+        with pytest.raises(RuntimeError):
+            wrapper().get_rule.side_effect = _get_rule_side_effect
+            wrapper().resolve.side_effect = _resolve_side_effect
+            await task.bundle()
 
     installers['apt'].add_to_install_list.assert_not_called()


### PR DESCRIPTION
Fetching the `ROS_DISTRO` environment variable was silently failing here with the `Could not find package` error when `ROS_DISTRO` was not set in the environment. The try-except block is catching the `KeyError` from `os.environ['ROS_DISTRO']` and skipping the `else` block where it logs and raises an error when `ROS_DISTRO` is not defined.

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>