### PR TITLE
Bump version to 0.1.0

### DIFF
--- a/colcon_ros_bundle/__init__.py
+++ b/colcon_ros_bundle/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = '0.0.15'
+__version__ = '0.1.0'

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -6,4 +6,4 @@ import colcon_ros_bundle
 
 def test_version():
     version = colcon_ros_bundle.__version__
-    assert version == '0.0.15'
+    assert version == '0.1.0'


### PR DESCRIPTION
Bump version of `colcon-ros-bundle` to `0.1.0`

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>