### PR TITLE
Bump actions/setup-python to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.5
     - name: Configure AWS Credentials


### PR DESCRIPTION
* GitHub Actions workflows are failing because cached python3.5 versions have been removed from x86 runners
  * More details in https://github.com/actions/virtual-environments/issues/4744
* Failure stack trace:

```
Run actions/setup-python@v1
  with:
    python-version: 3.5
    architecture: x64
Error: Version 3.5 with arch x64 not found
```

* Bump `actions/setup-python` to latest version v2 to allow it to setup pyhton3.5 successfully

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>