### PR TITLE
Installing python-pip or python3-pip based on python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This package is a plugin to [colcon-core](https://github.com/colcon/colcon-core.git),
 that contains extensions for [colcon-bundle](https://github.com/colcon/colcon-bundle).
 
-**NOTE:** `colcon-ros-bundle` only supports Ubuntu Xenial and Ubuntu Bionic operating systems and x86, ARMHF, and ARM64 architectures. All other operating systems and architectures are currently not supported. This code is in active development and **should not** be considered stable. 
+**NOTE:** `colcon-ros-bundle` only supports Ubuntu Xenial, Ubuntu Bionic, Ubuntu Focal operating systems and x86, ARMHF, and ARM64 architectures. All other operating systems and architectures are currently not supported. This code is in active development and **should not** be considered stable. 
 
 With this package you can use `colcon bundle` to create bundles of ROS applications. A
 bundle is a portable environment that allows for execution  of the

--- a/colcon_ros_bundle/task/ros_bundle.py
+++ b/colcon_ros_bundle/task/ros_bundle.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.task import TaskExtensionPoint
@@ -64,7 +65,13 @@ class RosBundle(TaskExtensionPoint):
                 # If the package requires pip, ensure pip is installed
                 # in the bundle
                 if rule_installer == 'pip':
-                    args.installers['apt'].add_to_install_list('python-pip')
+                    if sys.version_info.major == 2:
+                        args.installers['apt'].add_to_install_list('python-pip')
+                    elif sys.version_info.major == 3:
+                        args.installers['apt'].add_to_install_list('python3-pip')
+                    else:
+                        logger.error('Unable to determine python version.')
+                        raise RuntimeError('Unable to determine python version.')
 
                 package_name_list = rosdep.resolve(rule)
                 if len(package_name_list) == 0:


### PR DESCRIPTION
Using colcon-ros-bundle on Ubuntu Focal is difficult without some changes as indicated https://github.com/colcon/colcon-ros-bundle/issues/48.

This PR attempts to address this by inspecting which version of python that is running and installing the related Ubuntu `pip` package.