### PR TITLE
Use unittest.mock instead of standalone mock

### DIFF
--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -9,7 +9,6 @@ flake8-docstrings==1.3.0
 flake8-import-order==0.18.1
 flake8-polyfill==1.0.2
 flake8-quotes==2.0.1
-mock
 pep8-naming
 pyenchant
 pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ tests_require =
     flake8-docstrings
     flake8-import-order
     flake8-quotes
-    mock
     pep8-naming
     pyenchant
     pylint

--- a/test/test_catkin_bundle.py
+++ b/test/test_catkin_bundle.py
@@ -1,12 +1,13 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock, patch
+
 from colcon_bundle.verb.bundle import BundlePackageArguments
 from colcon_core.dependency_descriptor import DependencyDescriptor
 from colcon_core.package_descriptor import PackageDescriptor
 from colcon_core.task import TaskContext
 from colcon_ros_bundle.task.ros_bundle import RosBundle
-from mock import MagicMock, patch
 import pytest
 
 


### PR DESCRIPTION
The 'mock' backport package is not needed in Python >= 3.3, and is no longer packaged on some major Linux distributions.