### PR TITLE
Fix long_description file name for README.md

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 license = Apache License, Version 2.0
 keywords = colcon
 description = Plugin for colcon to bundle ros applications
-long_description = file: README.rst
+long_description = file: README.md
 [options]
 python_requires = >=3.5
 install_requires =


### PR DESCRIPTION
```
/usr/lib/python3.11/site-packages/setuptools/config/expand.py:142: UserWarning: File 'src/colcon-ros-bundle/README.rst' cannot be found
  warnings.warn(f"File {path!r} cannot be found")
```